### PR TITLE
Allow deleting actions

### DIFF
--- a/addons/bbcode_edit.editor/README.md
+++ b/addons/bbcode_edit.editor/README.md
@@ -87,8 +87,10 @@ You can download the addon:
 *By default, this readme is included, along with it's illustrations. If you don't want them,
 do not download `addons/bbcode_edit.editor/README.md` nor `addons/bbcode_edit.editor/.assets_for_readme/*`*
 
-To edit shortcuts, first restart the editor, then modify them,
-and restart the editor so that Godot updates the input map.
+To edit shortcuts:
+- *If they don't show up* in the input map GUI: first restart the editor
+- modify them in the input map GUI
+- **restart** the editor to update the input map.
 
 You can also exclude `*.editor/*` or `bbcode_edit.editor/` from your export presets,
 because this addon is (for now[^editor_only]) script-editor-only.

--- a/addons/bbcode_edit.editor/bbcode_edit.gd
+++ b/addons/bbcode_edit.editor/bbcode_edit.gd
@@ -18,6 +18,18 @@ enum CompletionKind {
 const Completions = preload("res://addons/bbcode_edit.editor/completions_db/completions.gd")
 const Scraper = preload("res://addons/bbcode_edit.editor/editor_interface_scraper.gd")
 
+const ACTION_TOGGLE_BOLD = &"bbcode_edit/toggle_bold"
+const ACTION_TOGGLE_ITALIC = &"bbcode_edit/toggle_italic"
+const ACTION_TOGGLE_UNDERLINE = &"bbcode_edit/toggle_underline"
+const ACTION_TOGGLE_STRIKE = &"bbcode_edit/toggle_strike"
+
+const TOGGLING_ACTIONS = {
+	ACTION_TOGGLE_BOLD: "b",
+	ACTION_TOGGLE_ITALIC: "i",
+	ACTION_TOGGLE_UNDERLINE: "u",
+	ACTION_TOGGLE_STRIKE: "s",
+}
+
 const BBCODE_COMPLETION_ICON = preload("res://addons/bbcode_edit.editor/bbcode_completion_icon.svg")
 const COLOR_PICKER_CONTAINER_PATH = ^"_BBCodeEditColorPicker"
 const COLOR_PICKER_PATH = ^"_BBCodeEditColorPicker/ColorPicker"
@@ -832,14 +844,13 @@ func _gui_input(event: InputEvent) -> void:
 		if event is InputEventKey or event is InputEventMouseButton:
 			get_node(COLOR_PICKER_CONTAINER_PATH).free()
 	
-	if event.is_action(&"bbcode_edit/toggle_bold", true):
-		toggle_tag("b")
-	elif event.is_action(&"bbcode_edit/toggle_italic", true):
-		toggle_tag("i")
-	elif event.is_action(&"bbcode_edit/toggle_underline", true):
-		toggle_tag("u")
-	elif event.is_action(&"bbcode_edit/toggle_strike", true):
-		toggle_tag("s")
+	for action in TOGGLING_ACTIONS:
+		if is_action(event, action):
+			toggle_tag(TOGGLING_ACTIONS[action])
+
+
+func is_action(event: InputEvent, action: StringName) -> bool:
+	return InputMap.has_action(action) and event.is_action(action, true)
 
 
 func _on_text_changed() -> void:

--- a/addons/bbcode_edit.editor/bbcode_edit_main.gd
+++ b/addons/bbcode_edit.editor/bbcode_edit_main.gd
@@ -48,6 +48,8 @@ func _on_editor_startup() -> void:
 	
 	# TODO check if InputMap.load_from_project_settings() is better
 	for setting in ACTION_SETTINGS:
+		if !ProjectSettings.has_setting(setting):
+			continue
 		var action_dict: Dictionary = ProjectSettings.get_setting(setting)
 		var action_name: StringName = setting.substr(6)
 		InputMap.add_action(action_name, action_dict["deadzone"])

--- a/addons/bbcode_edit.editor/bbcode_edit_main.gd
+++ b/addons/bbcode_edit.editor/bbcode_edit_main.gd
@@ -7,12 +7,13 @@ const Scraper = preload("res://addons/bbcode_edit.editor/editor_interface_scrape
 
 
 const ADDON_NAME = "BBCode Editor"
+const ACTION_OPEN_DOC = &"bbcode_edit/editor/open_current_file_documentation"
 const ACTION_SETTINGS: Array[StringName] = [
-	&"input/bbcode_edit/editor/open_current_file_documentation",
-	&"input/bbcode_edit/toggle_bold",
-	&"input/bbcode_edit/toggle_italic",
-	&"input/bbcode_edit/toggle_underline",
-	&"input/bbcode_edit/toggle_strike",
+	"input/" + ACTION_OPEN_DOC,
+	"input/" + BBCodeEdit.ACTION_TOGGLE_BOLD,
+	"input/" + BBCodeEdit.ACTION_TOGGLE_ITALIC,
+	"input/" + BBCodeEdit.ACTION_TOGGLE_UNDERLINE,
+	"input/" + BBCodeEdit.ACTION_TOGGLE_STRIKE,
 ]
 
 
@@ -131,7 +132,7 @@ func add_editor_keybinds() -> void:
 	open_current_file_documentation.shift_pressed = true
 	open_current_file_documentation.keycode = 4194332
 	ProjectSettings.set_setting(
-		&"input/bbcode_edit/editor/open_current_file_documentation",
+		"input/" + ACTION_OPEN_DOC,
 		{
 			"deadzone": 0.5,
 			"events": [open_current_file_documentation],
@@ -143,17 +144,17 @@ func add_editor_keybinds() -> void:
 
 
 func remove_keybinds() -> void:
-	ProjectSettings.set_setting(&"input/bbcode_edit/toggle_bold", null)
-	ProjectSettings.set_setting(&"input/bbcode_edit/toggle_italic", null)
-	ProjectSettings.set_setting(&"input/bbcode_edit/toggle_underline", null)
-	ProjectSettings.set_setting(&"input/bbcode_edit/toggle_strike", null)
+	ProjectSettings.set_setting("input/" + BBCodeEdit.ACTION_TOGGLE_BOLD, null)
+	ProjectSettings.set_setting("input/" + BBCodeEdit.ACTION_TOGGLE_ITALIC, null)
+	ProjectSettings.set_setting("input/" + BBCodeEdit.ACTION_TOGGLE_UNDERLINE, null)
+	ProjectSettings.set_setting("input/" + BBCodeEdit.ACTION_TOGGLE_STRIKE, null)
 	
 	# This calls ProjectSettings.save(), so please call it last
 	remove_editor_keybinds()
 
 
 func remove_editor_keybinds() -> void:
-	ProjectSettings.set_setting(&"input/bbcode_edit/editor/open_current_file_documentation", null)
+	ProjectSettings.set_setting("input/" + ACTION_OPEN_DOC, null)
 	ProjectSettings.save()
 
 
@@ -201,7 +202,10 @@ func open_doc(script: Script, code_edit: CodeEdit = null) -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	if InputMap.event_is_action(event, "bbcode_edit/editor/open_current_file_documentation", true):
+	if (
+		InputMap.has_action(ACTION_OPEN_DOC)
+		and InputMap.event_is_action(event, ACTION_OPEN_DOC, true)
+	):
 		# TODO find a workaround for the appearance delay of (*) to check unsaved status.
 		var current_editor := EditorInterface.get_script_editor().get_current_editor()
 		if current_editor == null:


### PR DESCRIPTION
This PR adds a check to ensure an action exists before testing if an event is an action.

This way, one can delete the actions created by this addon if they are bothering.

This PR also fix a potential annoying error at startup, if you somehow managed to trigger an `_unhandled_input()` while the addon was loading.